### PR TITLE
Add Industry & Lab Partnerships page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ preview
 preview.*
 .vscode/
 www
-
+CLAUDE.md

--- a/_static/css/grg/navbar.css
+++ b/_static/css/grg/navbar.css
@@ -72,6 +72,23 @@
   transform: scaleX(1);
 }
 
+.nav-link-cta {
+  background: rgba(255, 255, 255, 0.15);
+  padding: 0.35rem 0.9rem !important;
+  border-radius: 6px;
+  border: 1.5px solid rgba(255, 255, 255, 0.55);
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.nav-link-cta:hover {
+  background: rgba(255, 255, 255, 0.28);
+  border-color: rgba(255, 255, 255, 0.9);
+}
+
+.nav-link-cta:after {
+  display: none !important;
+}
+
 /* Mobile Navbar Styles */
 .mobile-navbar {
   display: none;

--- a/_static/css/grg/partnerships/partnerships.css
+++ b/_static/css/grg/partnerships/partnerships.css
@@ -693,12 +693,13 @@
   margin-bottom: 2.5rem;
 }
 
-.grant-awards-heading {
-  font-size: 1.05rem;
-  font-weight: 700;
-  color: #1a1a1a;
-  margin-bottom: 0.75rem;
+.grant-awards-context {
+  font-size: 0.9rem;
+  color: #636973;
+  line-height: 1.7;
   text-align: center;
+  max-width: 720px;
+  margin: 0 auto 1.25rem;
 }
 
 .grant-awards-table {

--- a/_static/css/grg/partnerships/partnerships.css
+++ b/_static/css/grg/partnerships/partnerships.css
@@ -76,12 +76,14 @@
 }
 
 .hero-btn-primary {
-  background: #ffffff;
-  color: #800000 !important;
+  background: #800000;
+  color: #ffffff !important;
+  border: 2px solid #800000;
 }
 
 .hero-btn-primary:hover {
-  opacity: 0.9;
+  background: #990000;
+  border-color: #990000;
   transform: translateY(-2px);
 }
 

--- a/_static/css/grg/partnerships/partnerships.css
+++ b/_static/css/grg/partnerships/partnerships.css
@@ -75,7 +75,10 @@
   cursor: pointer;
 }
 
-.hero-btn-primary {
+.hero-btn-primary,
+.hero-btn-primary:link,
+.hero-btn-primary:visited,
+.hero-btn-primary:active {
   background: #800000;
   color: #ffffff !important;
   border: 2px solid #800000;
@@ -84,6 +87,7 @@
 .hero-btn-primary:hover {
   background: #990000;
   border-color: #990000;
+  color: #ffffff !important;
   transform: translateY(-2px);
 }
 
@@ -508,7 +512,10 @@
   color: #ffffff !important;
 }
 
-.tier-cta-featured {
+.tier-cta-featured,
+.tier-cta-featured:link,
+.tier-cta-featured:visited,
+.tier-cta-featured:active {
   background: linear-gradient(135deg, #990000 0%, #800000 100%);
   color: #ffffff !important;
   border-color: transparent;
@@ -817,7 +824,10 @@
   margin: 0 auto 1.5rem;
 }
 
-.partnerships-cta-btn {
+.partnerships-cta-btn,
+.partnerships-cta-btn:link,
+.partnerships-cta-btn:visited,
+.partnerships-cta-btn:active {
   display: inline-block;
   padding: 1rem 2.5rem;
   background: linear-gradient(135deg, #990000 0%, #800000 100%);
@@ -833,6 +843,7 @@
 
 .partnerships-cta-btn:hover {
   opacity: 0.88;
+  color: #ffffff !important;
   transform: translateY(-2px);
 }
 
@@ -900,8 +911,15 @@
   opacity: 0.9;
 }
 
-.sticky-cta-email {
+.sticky-cta-email,
+.sticky-cta-email:link,
+.sticky-cta-email:visited,
+.sticky-cta-email:active {
   background: linear-gradient(135deg, #990000 0%, #800000 100%);
+  color: #ffffff !important;
+}
+
+.sticky-cta-email:hover {
   color: #ffffff !important;
 }
 

--- a/_static/css/grg/partnerships/partnerships.css
+++ b/_static/css/grg/partnerships/partnerships.css
@@ -190,7 +190,7 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 1.75rem;
-  align-items: start;
+  align-items: stretch;
 }
 
 .ecosystem-card {
@@ -204,12 +204,19 @@
 .ecosystem-card-featured {
   border-color: #800000;
   border-top-width: 4px;
+  height: 100%;
+  box-sizing: border-box;
 }
 
 .ecosystem-right {
   display: flex;
   flex-direction: column;
   gap: 1.75rem;
+  height: 100%;
+}
+
+.ecosystem-right .ecosystem-card {
+  flex: 1;
 }
 
 .ecosystem-card-header {

--- a/_static/css/grg/partnerships/partnerships.css
+++ b/_static/css/grg/partnerships/partnerships.css
@@ -11,7 +11,7 @@
 .partnerships-hero {
   position: relative;
   width: 100%;
-  height: 340px;
+  height: 360px;
   overflow: hidden;
 }
 
@@ -29,8 +29,8 @@
   inset: 0;
   background: linear-gradient(
     135deg,
-    rgba(128, 0, 0, 0.82) 0%,
-    rgba(20, 10, 10, 0.72) 100%
+    rgba(128, 0, 0, 0.84) 0%,
+    rgba(20, 10, 10, 0.74) 100%
   );
   display: flex;
   flex-direction: column;
@@ -51,11 +51,91 @@
 
 .partnerships-hero-subtitle {
   color: rgba(255, 255, 255, 0.9);
-  font-size: 1.1rem;
+  font-size: 1.05rem;
   font-weight: 400;
-  max-width: 720px;
+  max-width: 660px;
   line-height: 1.6;
-  margin: 0;
+  margin: 0 0 1.5rem;
+}
+
+.hero-cta-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.hero-btn {
+  padding: 0.75rem 2rem;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-decoration: none !important;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  cursor: pointer;
+}
+
+.hero-btn-primary {
+  background: #ffffff;
+  color: #800000 !important;
+}
+
+.hero-btn-primary:hover {
+  opacity: 0.9;
+  transform: translateY(-2px);
+}
+
+.hero-btn-secondary {
+  background: transparent;
+  color: #ffffff !important;
+  border: 2px solid rgba(255, 255, 255, 0.7);
+}
+
+.hero-btn-secondary:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: #ffffff;
+  transform: translateY(-2px);
+}
+
+/* --- Stats Bar --- */
+.stats-bar {
+  background: linear-gradient(135deg, #1a1a1a 0%, #2a2a2a 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0;
+  padding: 1.25rem 2rem;
+}
+
+.stat-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.5rem 2.5rem;
+}
+
+.stat-num {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #ffffff;
+  line-height: 1;
+}
+
+.stat-label {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+  text-align: center;
+  margin-top: 0.25rem;
+  max-width: 130px;
+  line-height: 1.3;
+}
+
+.stat-divider {
+  width: 1px;
+  height: 40px;
+  background: rgba(255, 255, 255, 0.15);
+  flex-shrink: 0;
 }
 
 /* --- Container --- */
@@ -104,6 +184,103 @@
   text-align: center;
   max-width: 800px;
   margin: 0 auto 2.5rem;
+}
+
+/* --- Ecosystem Section --- */
+.ecosystem-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.75rem;
+  align-items: start;
+}
+
+.ecosystem-card {
+  background: #ffffff;
+  border-radius: 14px;
+  padding: 1.75rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.07);
+  border: 1.5px solid #eeeeee;
+}
+
+.ecosystem-card-featured {
+  border-color: #800000;
+  border-top-width: 4px;
+}
+
+.ecosystem-right {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.ecosystem-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.ecosystem-logo {
+  height: 44px;
+  width: auto;
+}
+
+.ecosystem-hq-badge {
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: #ffffff;
+  background: linear-gradient(135deg, #990000 0%, #800000 100%);
+  border-radius: 20px;
+  padding: 0.3rem 0.85rem;
+}
+
+.ecosystem-card-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #1a1a1a;
+  margin: 0 0 0.75rem;
+}
+
+.ecosystem-card-body {
+  font-size: 0.9rem;
+  color: #4a4f5a;
+  line-height: 1.7;
+  margin: 0 0 1rem;
+}
+
+.ecosystem-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.eco-tag {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.7rem;
+  background: rgba(128, 0, 0, 0.07);
+  color: #800000;
+  border-radius: 20px;
+  font-weight: 500;
+}
+
+.ecosystem-link {
+  display: inline-block;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #800000 !important;
+  text-decoration: none !important;
+  border-bottom: 2px solid rgba(128, 0, 0, 0.3);
+  transition: border-color 0.2s ease;
+}
+
+.ecosystem-link:hover {
+  border-color: #800000;
 }
 
 /* --- Pillars --- */
@@ -168,7 +345,6 @@
   grid-template-columns: repeat(3, 1fr);
   gap: 2rem;
   align-items: start;
-  margin-bottom: 3rem;
 }
 
 .tier-card {
@@ -237,7 +413,7 @@
   display: flex;
   align-items: baseline;
   gap: 0.25rem;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.25rem;
 }
 
 .tier-amount {
@@ -250,6 +426,13 @@
 .tier-period {
   font-size: 0.95rem;
   color: #636973;
+}
+
+.tier-value-anchor {
+  font-size: 0.78rem;
+  color: #888;
+  font-style: italic;
+  margin: 0 0 0.6rem;
 }
 
 .tier-tagline {
@@ -328,94 +511,114 @@
   color: #ffffff !important;
 }
 
-/* --- Comparison Table --- */
-.tiers-table-wrap {
+/* --- Onboarding Timeline --- */
+.timeline {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.timeline-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.5rem;
   width: 100%;
-  overflow-x: auto;
 }
 
-.tiers-table-heading {
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: #1a1a1a;
-  margin-bottom: 1rem;
-  text-align: center;
-}
-
-.tiers-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.88rem;
-  border-radius: 12px;
-  overflow: hidden;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.07);
-}
-
-.tiers-table thead tr {
-  background: linear-gradient(135deg, #313132 0%, #1a1a1a 100%);
+.timeline-marker {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #990000 0%, #800000 100%);
   color: #ffffff;
+  font-size: 1.1rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  box-shadow: 0 4px 12px rgba(128, 0, 0, 0.3);
 }
 
-.tiers-table thead th {
-  padding: 1rem 1.25rem;
-  text-align: center;
-  font-weight: 600;
-  font-size: 0.85rem;
-  line-height: 1.5;
-}
-
-.tiers-table thead th:first-child {
-  text-align: left;
-}
-
-.tiers-table thead em {
-  display: block;
-  font-weight: 400;
-  font-size: 0.8rem;
-  opacity: 0.8;
-  margin-top: 0.15rem;
-}
-
-.tiers-table tbody tr:nth-child(even) {
-  background: #f8f8f9;
-}
-
-.tiers-table tbody tr:nth-child(odd) {
+.timeline-content {
   background: #ffffff;
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
+  flex: 1;
+  margin-bottom: 0;
 }
 
-.tiers-table tbody tr:hover {
-  background: rgba(128, 0, 0, 0.04);
-}
-
-.tiers-table td {
-  padding: 0.9rem 1.25rem;
-  color: #2a2a2a;
-  border-bottom: 1px solid #eeeeee;
-  vertical-align: top;
-}
-
-.tiers-table td:first-child {
-  font-weight: 600;
+.timeline-title {
+  font-size: 1rem;
+  font-weight: 700;
   color: #1a1a1a;
+  margin: 0 0 0.5rem;
 }
 
-.tiers-table td:not(:first-child) {
-  text-align: center;
+.timeline-body {
+  font-size: 0.88rem;
+  color: #4a4f5a;
+  line-height: 1.7;
+  margin: 0;
 }
 
-.col-featured {
-  background: rgba(128, 0, 0, 0.05) !important;
-  border-left: 2px solid rgba(128, 0, 0, 0.15);
-  border-right: 2px solid rgba(128, 0, 0, 0.15);
+.timeline-connector {
+  width: 2px;
+  height: 28px;
+  background: linear-gradient(to bottom, #800000, rgba(128,0,0,0.2));
+  margin-left: 21px;
 }
 
-.tiers-table thead .col-featured {
-  background: #800000 !important;
+/* --- Testimonials --- */
+.testimonials-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.75rem;
 }
 
-.cell-no {
-  color: #c0c4cc;
+.testimonial-card {
+  background: #ffffff;
+  border-radius: 14px;
+  padding: 1.75rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.07);
+  border: 1.5px solid #eeeeee;
+  min-height: 180px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.testimonial-placeholder {
+  border-style: dashed;
+  border-color: #d0d5dd;
+  background: #fafafa;
+}
+
+.testimonial-placeholder-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: 100%;
+  justify-content: space-between;
+}
+
+.testimonial-placeholder-text {
+  font-size: 0.9rem;
+  color: #aab0bb;
+  font-style: italic;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.testimonial-placeholder-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #c0c5ce;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 /* --- Grant Collaboration --- */
@@ -423,7 +626,7 @@
   display: flex;
   justify-content: center;
   gap: 3rem;
-  margin: 0 auto 2.5rem;
+  margin: 0 auto 1.5rem;
   flex-wrap: wrap;
 }
 
@@ -447,6 +650,27 @@
   text-align: center;
   max-width: 180px;
   line-height: 1.4;
+}
+
+.grant-awards-note {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+  font-size: 0.85rem;
+  color: #636973;
+}
+
+.grant-awards-label {
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.grant-award-placeholder {
+  color: #aab0bb;
+  font-style: italic;
 }
 
 .grant-grid {
@@ -485,10 +709,96 @@
   line-height: 1.6;
 }
 
+/* --- FAQ --- */
+.faq-list {
+  max-width: 800px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.faq-item {
+  background: #ffffff;
+  border-radius: 10px;
+  border: 1.5px solid #e8e8e8;
+  overflow: hidden;
+  transition: border-color 0.2s ease;
+}
+
+.faq-item.faq-open {
+  border-color: #800000;
+}
+
+.faq-question {
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 1.1rem 1.5rem;
+  text-align: left;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #1a1a1a;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  font-family: inherit;
+  transition: color 0.2s ease;
+}
+
+.faq-question:hover {
+  color: #800000;
+}
+
+.faq-item.faq-open .faq-question {
+  color: #800000;
+}
+
+.faq-icon {
+  font-size: 1.4rem;
+  font-weight: 400;
+  line-height: 1;
+  flex-shrink: 0;
+  transition: transform 0.25s ease;
+  color: #800000;
+}
+
+.faq-item.faq-open .faq-icon {
+  transform: rotate(45deg);
+}
+
+.faq-answer {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.35s ease;
+}
+
+.faq-item.faq-open .faq-answer {
+  max-height: 400px;
+}
+
+.faq-answer p {
+  padding: 0 1.5rem 1.25rem;
+  font-size: 0.9rem;
+  color: #4a4f5a;
+  line-height: 1.75;
+  margin: 0;
+}
+
 /* --- CTA Section --- */
 .partnerships-cta {
   text-align: center;
   padding: 2rem 0 1rem;
+}
+
+.cta-btn-row {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
 }
 
 .partnerships-cta-body {
@@ -518,6 +828,18 @@
   transform: translateY(-2px);
 }
 
+.partnerships-cta-btn-outline {
+  background: transparent;
+  color: #800000 !important;
+  border: 2px solid #800000;
+  box-shadow: none;
+}
+
+.partnerships-cta-btn-outline:hover {
+  background: rgba(128, 0, 0, 0.05);
+  opacity: 1;
+}
+
 .partnerships-billing-note {
   max-width: 680px;
   margin: 2rem auto 0;
@@ -531,35 +853,78 @@
   text-align: left;
 }
 
+/* --- Sticky Floating CTA --- */
+.sticky-cta {
+  position: fixed;
+  bottom: 1.75rem;
+  right: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  z-index: 500;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(12px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.sticky-cta.sticky-cta-visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.sticky-cta-btn {
+  display: block;
+  padding: 0.7rem 1.4rem;
+  border-radius: 8px;
+  font-size: 0.88rem;
+  font-weight: 700;
+  text-decoration: none !important;
+  text-align: center;
+  white-space: nowrap;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.22);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.sticky-cta-btn:hover {
+  transform: translateY(-2px);
+  opacity: 0.9;
+}
+
+.sticky-cta-email {
+  background: linear-gradient(135deg, #990000 0%, #800000 100%);
+  color: #ffffff !important;
+}
+
+.sticky-cta-call {
+  background: #ffffff;
+  color: #800000 !important;
+  border: 2px solid #800000;
+}
+
 /* =========================================================
    Responsive
    ========================================================= */
 @media (max-width: 1100px) {
-  .tiers-grid {
-    grid-template-columns: 1fr;
-    max-width: 520px;
-    margin-left: auto;
-    margin-right: auto;
-  }
-
-  .partnerships-pillars {
+  .tiers-grid,
+  .partnerships-pillars,
+  .grant-grid,
+  .testimonials-grid {
     grid-template-columns: 1fr;
     max-width: 560px;
     margin-left: auto;
     margin-right: auto;
   }
 
-  .grant-grid {
+  .ecosystem-grid {
     grid-template-columns: 1fr;
-    max-width: 560px;
-    margin-left: auto;
-    margin-right: auto;
   }
 }
 
 @media (max-width: 768px) {
   .partnerships-hero {
-    height: 260px;
+    height: 300px;
   }
 
   .partnerships-hero-title {
@@ -579,19 +944,32 @@
     padding: 40px 12px;
   }
 
-  .tiers-table {
-    font-size: 0.8rem;
+  .stats-bar {
+    gap: 0;
+    padding: 1rem;
   }
 
-  .tiers-table td,
-  .tiers-table th {
-    padding: 0.7rem 0.75rem;
+  .stat-item {
+    padding: 0.5rem 1.25rem;
+  }
+
+  .stat-divider {
+    display: none;
+  }
+
+  .stat-num {
+    font-size: 1.4rem;
+  }
+
+  .sticky-cta {
+    bottom: 1rem;
+    right: 1rem;
   }
 }
 
 @media (max-width: 480px) {
   .partnerships-hero {
-    height: 220px;
+    height: 240px;
   }
 
   .partnerships-hero-title {
@@ -604,5 +982,24 @@
 
   .tier-amount {
     font-size: 1.8rem;
+  }
+
+  .stats-bar {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .stat-divider {
+    display: none;
+  }
+
+  .hero-cta-row {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .hero-btn {
+    width: 100%;
+    max-width: 260px;
   }
 }

--- a/_static/css/grg/partnerships/partnerships.css
+++ b/_static/css/grg/partnerships/partnerships.css
@@ -600,40 +600,66 @@
   padding: 1.75rem;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.07);
   border: 1.5px solid #eeeeee;
-  min-height: 180px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-}
-
-.testimonial-placeholder {
-  border-style: dashed;
-  border-color: #d0d5dd;
-  background: #fafafa;
-}
-
-.testimonial-placeholder-inner {
+  border-top: 4px solid #800000;
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  height: 100%;
-  justify-content: space-between;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
-.testimonial-placeholder-text {
+.testimonial-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.1);
+}
+
+.testimonial-quote-mark {
+  font-size: 3rem;
+  line-height: 1;
+  color: #800000;
+  opacity: 0.25;
+  font-family: Georgia, serif;
+  display: block;
+  margin-bottom: -0.5rem;
+}
+
+.testimonial-text {
+  font-size: 0.92rem;
+  color: #2a2a2a;
+  line-height: 1.75;
+  font-style: italic;
+  margin: 0;
+  flex: 1;
+}
+
+.testimonial-author {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid #f0f0f0;
+}
+
+.testimonial-author-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.testimonial-name {
   font-size: 0.9rem;
+  font-weight: 700;
+  color: #1a1a1a;
+}
+
+.testimonial-role {
+  font-size: 0.8rem;
+  color: #636973;
+}
+
+.testimonial-source {
+  font-size: 0.75rem;
   color: #aab0bb;
   font-style: italic;
-  line-height: 1.6;
-  margin: 0;
-}
-
-.testimonial-placeholder-label {
-  font-size: 0.78rem;
-  font-weight: 600;
-  color: #c0c5ce;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
 }
 
 /* --- Grant Collaboration --- */

--- a/_static/css/grg/partnerships/partnerships.css
+++ b/_static/css/grg/partnerships/partnerships.css
@@ -688,6 +688,114 @@
   font-style: italic;
 }
 
+.grant-awards-table-wrap {
+  width: 100%;
+  margin-bottom: 2.5rem;
+}
+
+.grant-awards-heading {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #1a1a1a;
+  margin-bottom: 0.75rem;
+  text-align: center;
+}
+
+.grant-awards-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.07);
+  margin-bottom: 1.25rem;
+}
+
+.grant-awards-table thead tr {
+  background: linear-gradient(135deg, #313132 0%, #1a1a1a 100%);
+  color: #ffffff;
+}
+
+.grant-awards-table thead th {
+  padding: 0.85rem 1.25rem;
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.82rem;
+}
+
+.grant-awards-table tbody tr:nth-child(even) {
+  background: #f8f8f9;
+}
+
+.grant-awards-table tbody tr:nth-child(odd) {
+  background: #ffffff;
+}
+
+.grant-awards-table td {
+  padding: 0.9rem 1.25rem;
+  color: #2a2a2a;
+  border-bottom: 1px solid #eeeeee;
+  vertical-align: top;
+  line-height: 1.6;
+}
+
+.grant-awards-table td:first-child {
+  white-space: nowrap;
+  font-size: 0.8rem;
+}
+
+.grant-awards-table td:last-child {
+  white-space: nowrap;
+  font-weight: 600;
+  color: #800000;
+}
+
+.grant-awards-table code {
+  background: rgba(128, 0, 0, 0.07);
+  color: #800000;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-family: monospace;
+}
+
+.grant-cite-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: rgba(128, 0, 0, 0.1);
+  color: #800000;
+  border-radius: 20px;
+  padding: 0.15rem 0.6rem;
+  margin-left: 0.5rem;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.grant-foundation-support {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.grant-foundation-tags {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.grant-foundation-tag {
+  font-size: 0.8rem;
+  padding: 0.3rem 0.8rem;
+  background: #f0f0f2;
+  color: #3a3f4a;
+  border-radius: 20px;
+  font-weight: 500;
+}
+
 .grant-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/_static/css/grg/partnerships/partnerships.css
+++ b/_static/css/grg/partnerships/partnerships.css
@@ -1,0 +1,608 @@
+/* =========================================================
+   Partnerships Page
+   ========================================================= */
+
+.partnerships-page {
+  margin: 0;
+  padding: 0;
+}
+
+/* --- Hero --- */
+.partnerships-hero {
+  position: relative;
+  width: 100%;
+  height: 340px;
+  overflow: hidden;
+}
+
+#partnerships-banner {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center 40%;
+  display: block;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.15);
+}
+
+.partnerships-hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    135deg,
+    rgba(128, 0, 0, 0.82) 0%,
+    rgba(20, 10, 10, 0.72) 100%
+  );
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 10%;
+  text-align: center;
+}
+
+.partnerships-hero-title {
+  color: #ffffff;
+  font-size: 2.4rem;
+  font-weight: 700;
+  margin: 0 0 0.75rem;
+  line-height: 1.2;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+}
+
+.partnerships-hero-subtitle {
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 1.1rem;
+  font-weight: 400;
+  max-width: 720px;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* --- Container --- */
+.partnerships-container {
+  max-width: 80%;
+  margin: 0 auto;
+  padding: 60px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* --- Intro --- */
+.partnerships-intro {
+  width: 100%;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.partnerships-intro-text {
+  color: #636973;
+  font-size: 1.05rem;
+  line-height: 1.8;
+  max-width: 860px;
+  margin: 0 auto 1.5rem;
+}
+
+/* --- Section wrapper --- */
+.partnerships-section {
+  width: 100%;
+  margin: 2.5rem 0;
+}
+
+.partnerships-section-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #1a1a1a;
+  text-align: center;
+  margin-bottom: 0.5rem;
+}
+
+.partnerships-section-subtitle {
+  color: #636973;
+  font-size: 1rem;
+  line-height: 1.7;
+  text-align: center;
+  max-width: 800px;
+  margin: 0 auto 2.5rem;
+}
+
+/* --- Pillars --- */
+.partnerships-pillars {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2rem;
+}
+
+.pillar-card {
+  background: #ffffff;
+  border-radius: 14px;
+  padding: 2rem 1.5rem;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.07);
+  border-top: 4px solid #800000;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.pillar-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
+}
+
+.pillar-icon-wrap {
+  width: 56px;
+  height: 56px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #990000 0%, #800000 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1.25rem;
+  flex-shrink: 0;
+}
+
+.pillar-icon {
+  width: 30px;
+  height: 30px;
+  filter: brightness(0) invert(1);
+}
+
+.pillar-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #1a1a1a;
+  margin: 0 0 0.75rem;
+}
+
+.pillar-body {
+  font-size: 0.9rem;
+  color: #4a4f5a;
+  line-height: 1.7;
+  margin: 0;
+}
+
+/* --- Tier Cards --- */
+.tiers-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2rem;
+  align-items: start;
+  margin-bottom: 3rem;
+}
+
+.tier-card {
+  position: relative;
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 2rem 1.75rem 1.75rem;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.07);
+  border: 1.5px solid #e8e8e8;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.tier-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.11);
+}
+
+.tier-card.tier-featured {
+  border-color: #800000;
+  box-shadow: 0 8px 32px rgba(128, 0, 0, 0.18);
+}
+
+.tier-featured-badge {
+  position: absolute;
+  top: -14px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: linear-gradient(135deg, #990000 0%, #800000 100%);
+  color: #ffffff;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.3rem 1rem;
+  border-radius: 20px;
+  white-space: nowrap;
+}
+
+.tier-header {
+  margin-bottom: 1.5rem;
+}
+
+.tier-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #800000;
+  background: rgba(128, 0, 0, 0.08);
+  border-radius: 20px;
+  padding: 0.2rem 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.tier-name {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #1a1a1a;
+  margin: 0 0 0.75rem;
+}
+
+.tier-price {
+  display: flex;
+  align-items: baseline;
+  gap: 0.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.tier-amount {
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: #800000;
+  line-height: 1;
+}
+
+.tier-period {
+  font-size: 0.95rem;
+  color: #636973;
+}
+
+.tier-tagline {
+  font-size: 0.85rem;
+  color: #636973;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.tier-features {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  flex: 1;
+}
+
+.tier-features li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: #2a2a2a;
+}
+
+.feat-check {
+  color: #800000;
+  font-weight: 700;
+  font-size: 1rem;
+  line-height: 1.4;
+  flex-shrink: 0;
+}
+
+.feat-dash {
+  color: #c0c4cc;
+  font-size: 1rem;
+  line-height: 1.4;
+  flex-shrink: 0;
+}
+
+.feat-unavail {
+  color: #b0b5be;
+}
+
+.tier-cta {
+  display: block;
+  text-align: center;
+  padding: 0.8rem 1.5rem;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border: 2px solid #800000;
+  color: #800000 !important;
+  background: transparent;
+  transition: background 0.2s ease, color 0.2s ease;
+  cursor: pointer;
+  text-decoration: none !important;
+}
+
+.tier-cta:hover {
+  background: #800000;
+  color: #ffffff !important;
+}
+
+.tier-cta-featured {
+  background: linear-gradient(135deg, #990000 0%, #800000 100%);
+  color: #ffffff !important;
+  border-color: transparent;
+}
+
+.tier-cta-featured:hover {
+  background: linear-gradient(135deg, #b00000 0%, #990000 100%);
+  color: #ffffff !important;
+}
+
+/* --- Comparison Table --- */
+.tiers-table-wrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.tiers-table-heading {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1a1a1a;
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.tiers-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.07);
+}
+
+.tiers-table thead tr {
+  background: linear-gradient(135deg, #313132 0%, #1a1a1a 100%);
+  color: #ffffff;
+}
+
+.tiers-table thead th {
+  padding: 1rem 1.25rem;
+  text-align: center;
+  font-weight: 600;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.tiers-table thead th:first-child {
+  text-align: left;
+}
+
+.tiers-table thead em {
+  display: block;
+  font-weight: 400;
+  font-size: 0.8rem;
+  opacity: 0.8;
+  margin-top: 0.15rem;
+}
+
+.tiers-table tbody tr:nth-child(even) {
+  background: #f8f8f9;
+}
+
+.tiers-table tbody tr:nth-child(odd) {
+  background: #ffffff;
+}
+
+.tiers-table tbody tr:hover {
+  background: rgba(128, 0, 0, 0.04);
+}
+
+.tiers-table td {
+  padding: 0.9rem 1.25rem;
+  color: #2a2a2a;
+  border-bottom: 1px solid #eeeeee;
+  vertical-align: top;
+}
+
+.tiers-table td:first-child {
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.tiers-table td:not(:first-child) {
+  text-align: center;
+}
+
+.col-featured {
+  background: rgba(128, 0, 0, 0.05) !important;
+  border-left: 2px solid rgba(128, 0, 0, 0.15);
+  border-right: 2px solid rgba(128, 0, 0, 0.15);
+}
+
+.tiers-table thead .col-featured {
+  background: #800000 !important;
+}
+
+.cell-no {
+  color: #c0c4cc;
+}
+
+/* --- Grant Collaboration --- */
+.grant-track-record {
+  display: flex;
+  justify-content: center;
+  gap: 3rem;
+  margin: 0 auto 2.5rem;
+  flex-wrap: wrap;
+}
+
+.grant-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.grant-stat-num {
+  font-size: 2.8rem;
+  font-weight: 700;
+  color: #800000;
+  line-height: 1;
+}
+
+.grant-stat-label {
+  font-size: 0.85rem;
+  color: #636973;
+  text-align: center;
+  max-width: 180px;
+  line-height: 1.4;
+}
+
+.grant-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.75rem;
+  margin-bottom: 1rem;
+}
+
+.grant-card {
+  background: #ffffff;
+  border-radius: 14px;
+  padding: 1.75rem 1.5rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.07);
+  border-top: 4px solid #313132;
+}
+
+.grant-card-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1a1a1a;
+  margin: 0 0 1rem;
+}
+
+.grant-list {
+  padding-left: 1.25rem;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.grant-list li {
+  font-size: 0.875rem;
+  color: #3a3f4a;
+  line-height: 1.6;
+}
+
+/* --- CTA Section --- */
+.partnerships-cta {
+  text-align: center;
+  padding: 2rem 0 1rem;
+}
+
+.partnerships-cta-body {
+  color: #4a4f5a;
+  font-size: 1rem;
+  line-height: 1.8;
+  max-width: 740px;
+  margin: 0 auto 1.5rem;
+}
+
+.partnerships-cta-btn {
+  display: inline-block;
+  padding: 1rem 2.5rem;
+  background: linear-gradient(135deg, #990000 0%, #800000 100%);
+  color: #ffffff !important;
+  font-size: 1rem;
+  font-weight: 700;
+  border-radius: 8px;
+  text-decoration: none !important;
+  letter-spacing: 0.02em;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  box-shadow: 0 4px 16px rgba(128, 0, 0, 0.3);
+}
+
+.partnerships-cta-btn:hover {
+  opacity: 0.88;
+  transform: translateY(-2px);
+}
+
+.partnerships-billing-note {
+  max-width: 680px;
+  margin: 2rem auto 0;
+  padding: 1.25rem 1.75rem;
+  background: rgba(128, 0, 0, 0.05);
+  border-left: 4px solid #800000;
+  border-radius: 0 10px 10px 0;
+  font-size: 0.92rem;
+  color: #2a2a2a;
+  line-height: 1.7;
+  text-align: left;
+}
+
+/* =========================================================
+   Responsive
+   ========================================================= */
+@media (max-width: 1100px) {
+  .tiers-grid {
+    grid-template-columns: 1fr;
+    max-width: 520px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .partnerships-pillars {
+    grid-template-columns: 1fr;
+    max-width: 560px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .grant-grid {
+    grid-template-columns: 1fr;
+    max-width: 560px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+@media (max-width: 768px) {
+  .partnerships-hero {
+    height: 260px;
+  }
+
+  .partnerships-hero-title {
+    font-size: 1.6rem;
+  }
+
+  .partnerships-hero-subtitle {
+    font-size: 0.95rem;
+  }
+
+  .partnerships-hero-overlay {
+    padding: 1.5rem 6%;
+  }
+
+  .partnerships-container {
+    max-width: 92%;
+    padding: 40px 12px;
+  }
+
+  .tiers-table {
+    font-size: 0.8rem;
+  }
+
+  .tiers-table td,
+  .tiers-table th {
+    padding: 0.7rem 0.75rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .partnerships-hero {
+    height: 220px;
+  }
+
+  .partnerships-hero-title {
+    font-size: 1.3rem;
+  }
+
+  .partnerships-section-title {
+    font-size: 1.4rem;
+  }
+
+  .tier-amount {
+    font-size: 1.8rem;
+  }
+}

--- a/_static/css/grg/partnerships/partnerships.css
+++ b/_static/css/grg/partnerships/partnerships.css
@@ -86,14 +86,15 @@
 }
 
 .hero-btn-secondary {
-  background: transparent;
+  background: rgba(255, 255, 255, 0.18);
   color: #ffffff !important;
-  border: 2px solid rgba(255, 255, 255, 0.7);
+  border: 2px solid #ffffff;
+  backdrop-filter: blur(4px);
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
 }
 
 .hero-btn-secondary:hover {
-  background: rgba(255, 255, 255, 0.12);
-  border-color: #ffffff;
+  background: rgba(255, 255, 255, 0.32);
   transform: translateY(-2px);
 }
 

--- a/_static/css/grg/partnerships/partnerships.css
+++ b/_static/css/grg/partnerships/partnerships.css
@@ -86,15 +86,13 @@
 }
 
 .hero-btn-secondary {
-  background: rgba(255, 255, 255, 0.18);
-  color: #ffffff !important;
+  background: #ffffff;
+  color: #800000 !important;
   border: 2px solid #ffffff;
-  backdrop-filter: blur(4px);
-  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
 }
 
 .hero-btn-secondary:hover {
-  background: rgba(255, 255, 255, 0.32);
+  opacity: 0.9;
   transform: translateY(-2px);
 }
 

--- a/_static/css/main.css
+++ b/_static/css/main.css
@@ -26,3 +26,5 @@
 @import url("./grg/publications/papers.css");
 /* Software Page */
 @import url("./grg/software/software.css");
+/* Partnerships Page */
+@import url("./grg/partnerships/partnerships.css");

--- a/_templates/components/common/navbar.html
+++ b/_templates/components/common/navbar.html
@@ -22,6 +22,7 @@
         <a href="{{ pathto('publications') }}" class="nav-link">Publications</a>
         <a href="{{ pathto('software') }}" class="nav-link">Software</a>
         <a href="{{ pathto('career') }}" class="nav-link">Career</a>
+        <a href="{{ pathto('partnerships') }}" class="nav-link nav-link-cta">Partner</a>
       </div>
     </div>
   </nav>
@@ -54,6 +55,7 @@
       <a href="{{ pathto('publications') }}" class="nav-link">Publications</a>
       <a href="{{ pathto('software') }}" class="nav-link">Software</a>
       <a href="{{ pathto('career') }}" class="nav-link">Career</a>
+      <a href="{{ pathto('partnerships') }}" class="nav-link nav-link-cta">Partner</a>
     </div>
   </nav>
 </div>

--- a/_templates/pages/partnerships.html
+++ b/_templates/pages/partnerships.html
@@ -457,12 +457,8 @@
 
       <div class="grant-track-record">
         <div class="grant-stat">
-          <span class="grant-stat-num">$9.7M+</span>
-          <span class="grant-stat-label">Active NIH federal funding</span>
-        </div>
-        <div class="grant-stat">
           <span class="grant-stat-num">4</span>
-          <span class="grant-stat-label">Active NIH grants (BRAIN, NIA, NEI, NIBIB)</span>
+          <span class="grant-stat-label">Active NIH-funded projects (BRAIN, NIA, NEI, NIBIB)</span>
         </div>
         <div class="grant-stat">
           <span class="grant-stat-num">3+</span>
@@ -476,44 +472,48 @@
 
       <!-- Active NIH Grants -->
       <div class="grant-awards-table-wrap">
-        <h3 class="grant-awards-heading">Active Federal Funding</h3>
+        <p class="grant-awards-context">
+          GRG contributes as a key investigator or software lead on the following
+          federally funded research projects. These grants validate our technical
+          credibility and demonstrate the kind of work we bring to collaborative proposals.
+        </p>
         <table class="grant-awards-table">
           <thead>
             <tr>
               <th>Award</th>
-              <th>Title &amp; Focus</th>
-              <th>Amount</th>
+              <th>Focus</th>
+              <th>GRG Role</th>
             </tr>
           </thead>
           <tbody>
             <tr>
               <td><code>RF1MH121867</code></td>
               <td>
-                <strong>BRAIN Initiative 2.0</strong> — Community-supported software ecosystem for computational neuroanatomy; moves DIPY toward clinical deployment in neurosurgery and brain network mapping.
-                <span class="grant-cite-badge">Cite for DIPY usage 2024–2026</span>
+                <strong>BRAIN Initiative 2.0</strong> — Software ecosystem for computational neuroanatomy; clinical deployment of DIPY for neurosurgery and brain network mapping.
+                <span class="grant-cite-badge">Cite for DIPY 2024–2026</span>
               </td>
-              <td>~$2.3M</td>
+              <td>Software Lead</td>
             </tr>
             <tr>
               <td><code>R01AG075953</code></td>
               <td>
-                <strong>Alzheimer's Data Harmonization</strong> — Medical data harmonization software enabling comparison of MRI scans across different machines and hospitals for personalized Alzheimer's care.
+                <strong>Alzheimer's Harmonization</strong> — MRI data harmonization across scanners and institutions for personalized Alzheimer's care.
               </td>
-              <td>~$2.6M</td>
+              <td>Key Investigator</td>
             </tr>
             <tr>
               <td><code>R01EB027585</code></td>
               <td>
-                <strong>Brain Tractometry</strong> — Open-source software for brain tractometry processing, analysis, and insight. Also supported by NSF Grant 1934292.
+                <strong>Brain Tractometry</strong> — Open-source processing, analysis, and insight tools for white matter tractometry. Also supported by NSF #1934292.
               </td>
-              <td>—</td>
+              <td>Software Lead</td>
             </tr>
             <tr>
               <td><code>U01EY034630</code></td>
               <td>
-                <strong>Oculomics</strong> — Using the eye as a window into systemic health: Alzheimer's, diabetes, and cardiovascular disease detection via retinal imaging.
+                <strong>Oculomics</strong> — Retinal imaging as a biomarker for Alzheimer's, diabetes, and cardiovascular disease.
               </td>
-              <td>~$4.8M</td>
+              <td>Key Investigator</td>
             </tr>
           </tbody>
         </table>

--- a/_templates/pages/partnerships.html
+++ b/_templates/pages/partnerships.html
@@ -411,31 +411,48 @@
       </p>
       <div class="testimonials-grid">
 
-        <!-- TODO: replace with real testimonials -->
-        <div class="testimonial-card testimonial-placeholder">
-          <div class="testimonial-placeholder-inner">
-            <p class="testimonial-placeholder-text">
-              Testimonial from a partner researcher or lab director coming soon.
-            </p>
-            <span class="testimonial-placeholder-label">Academic Partner — Neuroimaging Lab</span>
+        <div class="testimonial-card">
+          <span class="testimonial-quote-mark">&#8220;</span>
+          <p class="testimonial-text">
+            The DiPy workshop is an intense but informative overview of cutting edge
+            Diffusion Imaging techniques. I'm honored to have the opportunity to
+            attend for several years now.
+          </p>
+          <div class="testimonial-author">
+            <div class="testimonial-author-info">
+              <span class="testimonial-name">Dianne Patterson</span>
+              <span class="testimonial-role">Program Coordinator &amp; Instructor</span>
+              <span class="testimonial-source">DIPY Workshop 2024 — LinkedIn</span>
+            </div>
           </div>
         </div>
 
-        <div class="testimonial-card testimonial-placeholder">
-          <div class="testimonial-placeholder-inner">
-            <p class="testimonial-placeholder-text">
-              Testimonial from a corporate R&amp;D partner coming soon.
-            </p>
-            <span class="testimonial-placeholder-label">Corporate R&amp;D Partner — Medtech</span>
+        <div class="testimonial-card">
+          <span class="testimonial-quote-mark">&#8220;</span>
+          <p class="testimonial-text">
+            Thank you very much everyone for this invaluable workshop!!
+          </p>
+          <div class="testimonial-author">
+            <div class="testimonial-author-info">
+              <span class="testimonial-name">Luis Jimenez Angeles</span>
+              <span class="testimonial-role">Workshop Participant</span>
+              <span class="testimonial-source">DIPY Workshop — Live Session</span>
+            </div>
           </div>
         </div>
 
-        <div class="testimonial-card testimonial-placeholder">
-          <div class="testimonial-placeholder-inner">
-            <p class="testimonial-placeholder-text">
-              Testimonial from a clinical sponsor or grant collaborator coming soon.
-            </p>
-            <span class="testimonial-placeholder-label">Enterprise Partner — Clinical Trial</span>
+        <div class="testimonial-card">
+          <span class="testimonial-quote-mark">&#8220;</span>
+          <p class="testimonial-text">
+            It looks that the workshop has been precisely what I'm looking for to
+            use in my research work on Cognitive Disabilities.
+          </p>
+          <div class="testimonial-author">
+            <div class="testimonial-author-info">
+              <span class="testimonial-name">Jorge Palacios</span>
+              <span class="testimonial-role">Researcher — Cognitive Disabilities</span>
+              <span class="testimonial-source">DIPY Workshop — Direct Message</span>
+            </div>
           </div>
         </div>
 

--- a/_templates/pages/partnerships.html
+++ b/_templates/pages/partnerships.html
@@ -35,7 +35,7 @@
     </div>
     <div class="stat-divider"></div>
     <div class="stat-item">
-      <span class="stat-num">700+</span>
+      <span class="stat-num">1500+</span>
       <span class="stat-label">peer-reviewed citations</span>
     </div>
     <div class="stat-divider"></div>
@@ -270,11 +270,11 @@
             </li>
             <li>
               <span class="feat-check">&#10003;</span>
-              <span><strong>Support Channels</strong> — Private Slack channel + dedicated email (24-hour response)</span>
+              <span><strong>Support Channels</strong> — Private Google Chat space + dedicated email (24-hour response)</span>
             </li>
             <li>
               <span class="feat-check">&#10003;</span>
-              <span><strong>Private Consult Hours</strong> — 16 hours / year of direct consultation with core developers</span>
+              <span><strong>Private Consult Hours</strong> — 8 hours / year of direct consultation with core developers</span>
             </li>
             <li>
               <span class="feat-check">&#10003;</span>
@@ -312,15 +312,15 @@
           <ul class="tier-features">
             <li>
               <span class="feat-check">&#10003;</span>
-              <span><strong>Workshop Access</strong> — Unlimited team seats + private half-day session with GRG leadership</span>
+              <span><strong>Workshop Access</strong> — Up to 25 R&amp;D team seats + private half-day session with GRG leadership</span>
             </li>
             <li>
               <span class="feat-check">&#10003;</span>
-              <span><strong>Support Channels</strong> — Named point-of-contact engineer + phone escalation path</span>
+              <span><strong>Support Channels</strong> — Named point-of-contact engineer + dedicated email (12-hour response)</span>
             </li>
             <li>
               <span class="feat-check">&#10003;</span>
-              <span><strong>Private Consult Hours</strong> — 48 hours / year + quarterly strategic review sessions</span>
+              <span><strong>Private Consult Hours</strong> — 32 hours / year + quarterly strategic review sessions</span>
             </li>
             <li>
               <span class="feat-check">&#10003;</span>
@@ -328,7 +328,7 @@
             </li>
             <li>
               <span class="feat-check">&#10003;</span>
-              <span><strong>Regulatory Compliance Docs</strong> — Algorithmic validation reports, reproducibility datasets, and IU-signed technical letters</span>
+              <span><strong>Regulatory Compliance Docs</strong> — Algorithmic validation reports and reproducibility datasets</span>
             </li>
             <li>
               <span class="feat-check">&#10003;</span>
@@ -358,7 +358,7 @@
             <h4 class="timeline-title">Day 1 — Welcome &amp; Access</h4>
             <p class="timeline-body">
               IU invoice or PO processed. You receive a welcome email with your
-              dedicated contact, Slack channel invite (Corporate+), and a link to
+              dedicated contact, Google Chat space invite (Corporate+), and a link to
               schedule your onboarding call.
             </p>
           </div>

--- a/_templates/pages/partnerships.html
+++ b/_templates/pages/partnerships.html
@@ -16,7 +16,7 @@
         behind DIPY, FURY, and THETAN.
       </p>
       <div class="hero-cta-row">
-        <a href="mailto:workshop@dipy.org?subject=Partnership Inquiry" class="hero-btn hero-btn-primary">
+        <a href="mailto:admins@dipy.org?subject=Partnership Inquiry" class="hero-btn hero-btn-primary">
           Email Us
         </a>
         <a href="https://calendar.app.google/H5gG9o2b2SfcrsQV7" target="_blank" rel="noopener noreferrer" class="hero-btn hero-btn-secondary">
@@ -196,7 +196,7 @@
       <p class="partnerships-section-subtitle">
         All tiers include access to our open-source ecosystems — premium layers add
         direct human expertise. Not sure which fits?
-        <a href="mailto:workshop@dipy.org?subject=Tier Question" style="color:#800000;">Ask us</a>.
+        <a href="mailto:admins@dipy.org?subject=Tier Question" style="color:#800000;">Ask us</a>.
       </p>
 
       <div class="tiers-grid">
@@ -241,7 +241,7 @@
               <span class="feat-unavail">SLA &amp; Priority Patching</span>
             </li>
           </ul>
-          <a href="mailto:workshop@dipy.org?subject=Academic Lab Partnership Inquiry" class="tier-cta">
+          <a href="mailto:admins@dipy.org?subject=Academic Lab Partnership Inquiry" class="tier-cta">
             Get Started
           </a>
         </div>
@@ -288,7 +288,7 @@
               <span><strong>SLA &amp; Priority Patching</strong> — Critical bug fixes prioritized within 5 business days</span>
             </li>
           </ul>
-          <a href="mailto:workshop@dipy.org?subject=Corporate R%26D Partnership Inquiry" class="tier-cta tier-cta-featured">
+          <a href="mailto:admins@dipy.org?subject=Corporate R%26D Partnership Inquiry" class="tier-cta tier-cta-featured">
             Get Started
           </a>
         </div>
@@ -334,7 +334,7 @@
               <span><strong>SLA &amp; Priority Patching</strong> — Guaranteed 48-hour critical response with root-cause analysis report</span>
             </li>
           </ul>
-          <a href="mailto:workshop@dipy.org?subject=Enterprise Clinical Sponsorship Inquiry" class="tier-cta">
+          <a href="mailto:admins@dipy.org?subject=Enterprise Clinical Sponsorship Inquiry" class="tier-cta">
             Contact Us
           </a>
         </div>
@@ -569,7 +569,7 @@
         4–6 weeks before your submission deadline — so we have time to prepare
         the necessary documents and coordinate with
         <strong>IU Sponsored Research Services</strong>.
-        Email <a href="mailto:workshop@dipy.org?subject=Grant Collaboration Inquiry" style="color: #800000;">workshop@dipy.org</a>
+        Email <a href="mailto:admins@dipy.org?subject=Grant Collaboration Inquiry" style="color: #800000;">admins@dipy.org</a>
         with your funding opportunity number and target submission date.
       </blockquote>
     </div>
@@ -693,10 +693,10 @@
       </p>
       <div class="cta-btn-row">
         <a
-          href="mailto:workshop@dipy.org?subject=Partnership Inquiry"
+          href="mailto:admins@dipy.org?subject=Partnership Inquiry"
           class="partnerships-cta-btn"
         >
-          Email workshop@dipy.org
+          Email admins@dipy.org
         </a>
         <a
           href="https://calendar.app.google/H5gG9o2b2SfcrsQV7"
@@ -727,7 +727,7 @@
 
 <!-- STICKY FLOATING CTA -->
 <div class="sticky-cta" id="stickyCta">
-  <a href="mailto:workshop@dipy.org?subject=Partnership Inquiry" class="sticky-cta-btn sticky-cta-email">
+  <a href="mailto:admins@dipy.org?subject=Partnership Inquiry" class="sticky-cta-btn sticky-cta-email">
     Email Us
   </a>
   <!-- TODO: replace # with Google Calendar booking URL -->

--- a/_templates/pages/partnerships.html
+++ b/_templates/pages/partnerships.html
@@ -35,7 +35,7 @@
     </div>
     <div class="stat-divider"></div>
     <div class="stat-item">
-      <span class="stat-num">1500+</span>
+      <span class="stat-num">1,500+</span>
       <span class="stat-label">peer-reviewed citations</span>
     </div>
     <div class="stat-divider"></div>
@@ -457,12 +457,16 @@
 
       <div class="grant-track-record">
         <div class="grant-stat">
-          <span class="grant-stat-num">20+</span>
-          <span class="grant-stat-label">Years of NIH &amp; NSF-funded research</span>
+          <span class="grant-stat-num">$9.7M+</span>
+          <span class="grant-stat-label">Active NIH federal funding</span>
         </div>
         <div class="grant-stat">
-          <span class="grant-stat-num">3</span>
-          <span class="grant-stat-label">Active open-source ecosystems (DIPY, FURY, THETAN)</span>
+          <span class="grant-stat-num">4</span>
+          <span class="grant-stat-label">Active NIH grants (BRAIN, NIA, NEI, NIBIB)</span>
+        </div>
+        <div class="grant-stat">
+          <span class="grant-stat-num">3+</span>
+          <span class="grant-stat-label">Foundation funders (CZI, Sloan, NSF)</span>
         </div>
         <div class="grant-stat">
           <span class="grant-stat-num">R1</span>
@@ -470,10 +474,58 @@
         </div>
       </div>
 
-      <!-- TODO: add real NIH/NSF award IDs below when available -->
-      <div class="grant-awards-note">
-        <span class="grant-awards-label">Selected funded awards:</span>
-        <span class="grant-award-placeholder">NIH Award #XXXXXXXX &nbsp;|&nbsp; NSF Award #XXXXXXX &nbsp;|&nbsp; <em>Additional awards to be listed</em></span>
+      <!-- Active NIH Grants -->
+      <div class="grant-awards-table-wrap">
+        <h3 class="grant-awards-heading">Active Federal Funding</h3>
+        <table class="grant-awards-table">
+          <thead>
+            <tr>
+              <th>Award</th>
+              <th>Title &amp; Focus</th>
+              <th>Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>RF1MH121867</code></td>
+              <td>
+                <strong>BRAIN Initiative 2.0</strong> — Community-supported software ecosystem for computational neuroanatomy; moves DIPY toward clinical deployment in neurosurgery and brain network mapping.
+                <span class="grant-cite-badge">Cite for DIPY usage 2024–2026</span>
+              </td>
+              <td>~$2.3M</td>
+            </tr>
+            <tr>
+              <td><code>R01AG075953</code></td>
+              <td>
+                <strong>Alzheimer's Data Harmonization</strong> — Medical data harmonization software enabling comparison of MRI scans across different machines and hospitals for personalized Alzheimer's care.
+              </td>
+              <td>~$2.6M</td>
+            </tr>
+            <tr>
+              <td><code>R01EB027585</code></td>
+              <td>
+                <strong>Brain Tractometry</strong> — Open-source software for brain tractometry processing, analysis, and insight. Also supported by NSF Grant 1934292.
+              </td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>U01EY034630</code></td>
+              <td>
+                <strong>Oculomics</strong> — Using the eye as a window into systemic health: Alzheimer's, diabetes, and cardiovascular disease detection via retinal imaging.
+              </td>
+              <td>~$4.8M</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="grant-foundation-support">
+          <span class="grant-awards-label">Additional support from:</span>
+          <div class="grant-foundation-tags">
+            <span class="grant-foundation-tag">NSF #1934292</span>
+            <span class="grant-foundation-tag">Chan Zuckerberg Initiative (EOSS)</span>
+            <span class="grant-foundation-tag">Alfred P. Sloan Foundation</span>
+          </div>
+        </div>
       </div>
 
       <div class="grant-grid">
@@ -481,11 +533,11 @@
         <div class="grant-card">
           <h3 class="grant-card-title">What We Bring to Your Proposal</h3>
           <ul class="grant-list">
-            <li>Established computational neuroimaging pipeline (DIPY) already cited in 700+ peer-reviewed publications</li>
-            <li>Expertise in diffusion MRI, tractography, and brain connectivity analysis</li>
+            <li>DIPY cited in 1,500+ peer-reviewed publications and actively funded by NIH BRAIN Initiative, NIA, NEI, and NSF</li>
+            <li>Expertise spanning diffusion MRI, tractography, brain connectivity, oculomics, and data harmonization</li>
             <li>Machine learning and scientific visualization capabilities (FURY, THETAN)</li>
-            <li>A multidisciplinary team spanning ISE, neuroscience, and clinical imaging</li>
-            <li>Proven ability to deliver reproducible, open-source software artifacts required by NIH data-sharing mandates</li>
+            <li>Multidisciplinary team spanning ISE, neuroscience, ophthalmology, and clinical imaging</li>
+            <li>Proven delivery of reproducible, open-source artifacts meeting NIH data-sharing mandates</li>
           </ul>
         </div>
 
@@ -503,7 +555,7 @@
         <div class="grant-card">
           <h3 class="grant-card-title">Common Collaboration Mechanisms</h3>
           <ul class="grant-list">
-            <li><strong>NIH R01 / R21 subaward</strong> — GRG listed as subcontractor with dedicated budget</li>
+            <li><strong>NIH R01 / R21 / U01 subaward</strong> — GRG listed as subcontractor with dedicated budget</li>
             <li><strong>NSF collaborative research</strong> — multi-PI or subaward structure through IU Sponsored Programs</li>
             <li><strong>Consultant role</strong> — lighter engagement, no subcontract needed</li>
             <li><strong>Co-investigator</strong> — for deeper, multi-year research partnerships where GRG leads a specific aim</li>

--- a/_templates/pages/partnerships.html
+++ b/_templates/pages/partnerships.html
@@ -1,0 +1,397 @@
+{% extends "layout.html" %} {% set title = 'Industry & Lab Partnerships' %} {% block docs_main %}
+
+<section class="partnerships-page">
+
+  <!-- HERO -->
+  <div class="partnerships-hero">
+    <img
+      id="partnerships-banner"
+      src="_static/images/banner/research.jpg"
+      alt="GRG Industry Partnerships"
+    />
+    <div class="partnerships-hero-overlay">
+      <h1 class="partnerships-hero-title">GRG Industry &amp; Partnership Ecosystem</h1>
+      <p class="partnerships-hero-subtitle">
+        Accelerate your neuroimaging pipelines with direct access to the innovators
+        behind DIPY, FURY, and THETAN.
+      </p>
+    </div>
+  </div>
+
+  <div class="partnerships-container">
+
+    <!-- INTRO -->
+    <div class="partnerships-intro">
+      <p class="partnerships-intro-text">
+        While our core software remains completely open-source and free for the world,
+        the Garyfallidis Research Group provides structured premium partnerships for
+        academic labs and corporate teams requiring enterprise-grade optimization,
+        sequence validation, and clinical trial compliance.
+      </p>
+      <div class="divider"></div>
+    </div>
+
+    <!-- WHY PARTNER -->
+    <div class="partnerships-section" id="why-partner">
+      <h2 class="partnerships-section-title">Why Partner with GRG?</h2>
+      <p class="partnerships-section-subtitle">
+        Bridging cutting-edge computational neuroengineering and real-world industrial
+        applications, GRG partnerships give your team an unfair advantage.
+      </p>
+      <div class="partnerships-pillars">
+
+        <div class="pillar-card">
+          <div class="pillar-icon-wrap">
+            <img src="_static/images/icons/ml.svg" alt="Engineering" class="pillar-icon" />
+          </div>
+          <h3 class="pillar-title">Eliminate Engineering Bottlenecks</h3>
+          <p class="pillar-body">
+            Direct access to core maintainers of DIPY, FURY, and THETAN to optimize
+            processing pipelines, configuration tuning, and throughput — eliminating
+            the months your team would otherwise spend reverse-engineering undocumented
+            internals.
+          </p>
+        </div>
+
+        <div class="pillar-card">
+          <div class="pillar-icon-wrap">
+            <img src="_static/images/icons/brain.svg" alt="Sequence Validation" class="pillar-icon" />
+          </div>
+          <h3 class="pillar-title">Sequence Validation</h3>
+          <p class="pillar-body">
+            Expert consulting on optimal diffusion acquisition strategies — multishell
+            b-value schemes, directional resolution for crossing fibers, and protocol
+            harmonization across scanner platforms — grounded in two decades of
+            hands-on MRI research.
+          </p>
+        </div>
+
+        <div class="pillar-card">
+          <div class="pillar-icon-wrap">
+            <img src="_static/images/icons/info.svg" alt="Regulatory" class="pillar-icon" />
+          </div>
+          <h3 class="pillar-title">Regulatory &amp; Compliance Support</h3>
+          <p class="pillar-body">
+            Algorithmic documentation, validation datasets, and reproducibility
+            evidence essential for FDA submissions and clinical trial compliance.
+            Leverage an R1 university research group's institutional credibility for
+            your regulatory pathway.
+          </p>
+        </div>
+
+      </div>
+    </div>
+
+    <div class="divider"></div>
+
+    <!-- PRICING TIERS -->
+    <div class="partnerships-section" id="tiers">
+      <h2 class="partnerships-section-title">Premium Partnership Tiers</h2>
+      <p class="partnerships-section-subtitle">
+        Choose the engagement level that fits your team's scale, timeline, and
+        technical requirements. All tiers include access to our open-source
+        ecosystems; premium layers add direct human expertise.
+      </p>
+
+      <div class="tiers-grid">
+
+        <!-- TIER 1 -->
+        <div class="tier-card tier-academic">
+          <div class="tier-header">
+            <span class="tier-badge">Academic</span>
+            <h3 class="tier-name">Academic Lab</h3>
+            <div class="tier-price">
+              <span class="tier-amount">$2,500</span>
+              <span class="tier-period">/ year</span>
+            </div>
+            <p class="tier-tagline">
+              For research groups leveraging GRG software in grant-funded studies.
+            </p>
+          </div>
+          <ul class="tier-features">
+            <li>
+              <span class="feat-check">&#10003;</span>
+              <span><strong>Workshop Access</strong> — Priority registration &amp; discounted seats at annual DIPY workshops</span>
+            </li>
+            <li>
+              <span class="feat-check">&#10003;</span>
+              <span><strong>Support Channels</strong> — Dedicated GitHub issue lane + email queue (48-hour response)</span>
+            </li>
+            <li>
+              <span class="feat-check">&#10003;</span>
+              <span><strong>Private Consult Hours</strong> — 4 hours / year of direct video consultation</span>
+            </li>
+            <li>
+              <span class="feat-dash">&#8212;</span>
+              <span class="feat-unavail">Custom Algorithm Adaptation</span>
+            </li>
+            <li>
+              <span class="feat-dash">&#8212;</span>
+              <span class="feat-unavail">Regulatory Compliance Docs</span>
+            </li>
+            <li>
+              <span class="feat-dash">&#8212;</span>
+              <span class="feat-unavail">SLA &amp; Priority Patching</span>
+            </li>
+          </ul>
+          <a href="mailto:workshop@dipy.org?subject=Academic Lab Partnership Inquiry" class="tier-cta">
+            Get Started
+          </a>
+        </div>
+
+        <!-- TIER 2 -->
+        <div class="tier-card tier-corporate tier-featured">
+          <div class="tier-featured-badge">Most Popular</div>
+          <div class="tier-header">
+            <span class="tier-badge">Corporate</span>
+            <h3 class="tier-name">Corporate R&amp;D Partner</h3>
+            <div class="tier-price">
+              <span class="tier-amount">$7,500</span>
+              <span class="tier-period">/ year</span>
+            </div>
+            <p class="tier-tagline">
+              For biotech, medtech, and pharmaceutical R&amp;D teams integrating
+              GRG pipelines into product workflows.
+            </p>
+          </div>
+          <ul class="tier-features">
+            <li>
+              <span class="feat-check">&#10003;</span>
+              <span><strong>Workshop Access</strong> — Complimentary seats (up to 3 attendees) at annual workshops</span>
+            </li>
+            <li>
+              <span class="feat-check">&#10003;</span>
+              <span><strong>Support Channels</strong> — Private Slack channel + dedicated email (24-hour response)</span>
+            </li>
+            <li>
+              <span class="feat-check">&#10003;</span>
+              <span><strong>Private Consult Hours</strong> — 16 hours / year of direct consultation with core developers</span>
+            </li>
+            <li>
+              <span class="feat-check">&#10003;</span>
+              <span><strong>Custom Algorithm Adaptation</strong> — Minor pipeline customizations scoped annually</span>
+            </li>
+            <li>
+              <span class="feat-dash">&#8212;</span>
+              <span class="feat-unavail">Regulatory Compliance Docs</span>
+            </li>
+            <li>
+              <span class="feat-check">&#10003;</span>
+              <span><strong>SLA &amp; Priority Patching</strong> — Critical bug fixes prioritized within 5 business days</span>
+            </li>
+          </ul>
+          <a href="mailto:workshop@dipy.org?subject=Corporate R%26D Partnership Inquiry" class="tier-cta tier-cta-featured">
+            Get Started
+          </a>
+        </div>
+
+        <!-- TIER 3 -->
+        <div class="tier-card tier-enterprise">
+          <div class="tier-header">
+            <span class="tier-badge">Enterprise</span>
+            <h3 class="tier-name">Enterprise &amp; Clinical Sponsor</h3>
+            <div class="tier-price">
+              <span class="tier-amount">$20,000</span>
+              <span class="tier-period">/ year</span>
+            </div>
+            <p class="tier-tagline">
+              For clinical-stage organizations requiring full validation support,
+              regulatory-grade documentation, and named engineering resources.
+            </p>
+          </div>
+          <ul class="tier-features">
+            <li>
+              <span class="feat-check">&#10003;</span>
+              <span><strong>Workshop Access</strong> — Unlimited team seats + private half-day session with GRG leadership</span>
+            </li>
+            <li>
+              <span class="feat-check">&#10003;</span>
+              <span><strong>Support Channels</strong> — Named point-of-contact engineer + phone escalation path</span>
+            </li>
+            <li>
+              <span class="feat-check">&#10003;</span>
+              <span><strong>Private Consult Hours</strong> — 48 hours / year + quarterly strategic review sessions</span>
+            </li>
+            <li>
+              <span class="feat-check">&#10003;</span>
+              <span><strong>Custom Algorithm Adaptation</strong> — Substantial customization and co-development scope</span>
+            </li>
+            <li>
+              <span class="feat-check">&#10003;</span>
+              <span><strong>Regulatory Compliance Docs</strong> — Algorithmic validation reports, reproducibility datasets, and IU-signed technical letters</span>
+            </li>
+            <li>
+              <span class="feat-check">&#10003;</span>
+              <span><strong>SLA &amp; Priority Patching</strong> — Guaranteed 48-hour critical response with root-cause analysis report</span>
+            </li>
+          </ul>
+          <a href="mailto:workshop@dipy.org?subject=Enterprise Clinical Sponsorship Inquiry" class="tier-cta">
+            Contact Us
+          </a>
+        </div>
+
+      </div>
+
+      <!-- Comparison summary table -->
+      <div class="tiers-table-wrap">
+        <h3 class="tiers-table-heading">At a Glance</h3>
+        <table class="tiers-table">
+          <thead>
+            <tr>
+              <th>Feature</th>
+              <th>Academic Lab<br /><em>$2,500 / yr</em></th>
+              <th class="col-featured">Corporate R&amp;D<br /><em>$7,500 / yr</em></th>
+              <th>Enterprise &amp; Clinical<br /><em>$20,000 / yr</em></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Workshop Access</td>
+              <td>Priority &amp; discounted</td>
+              <td class="col-featured">Up to 3 complimentary seats</td>
+              <td>Unlimited + private session</td>
+            </tr>
+            <tr>
+              <td>Support Channels</td>
+              <td>GitHub lane + email (48 hr)</td>
+              <td class="col-featured">Private Slack + email (24 hr)</td>
+              <td>Named engineer + phone</td>
+            </tr>
+            <tr>
+              <td>Private Consult Hours</td>
+              <td>4 hr / yr</td>
+              <td class="col-featured">16 hr / yr</td>
+              <td>48 hr / yr + quarterly reviews</td>
+            </tr>
+            <tr>
+              <td>Custom Algorithm Adaptation</td>
+              <td class="cell-no">&#8212;</td>
+              <td class="col-featured">Minor scope</td>
+              <td>Substantial co-development</td>
+            </tr>
+            <tr>
+              <td>Regulatory Compliance Docs</td>
+              <td class="cell-no">&#8212;</td>
+              <td class="col-featured cell-no">&#8212;</td>
+              <td>Full package + IU-signed letters</td>
+            </tr>
+            <tr>
+              <td>SLA &amp; Priority Patching</td>
+              <td class="cell-no">&#8212;</td>
+              <td class="col-featured">5 business days</td>
+              <td>48-hour critical response</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="divider"></div>
+
+    <!-- GRANT COLLABORATION -->
+    <div class="partnerships-section" id="grant-collaboration">
+      <h2 class="partnerships-section-title">Include GRG in Your Grant</h2>
+      <p class="partnerships-section-subtitle">
+        GRG has a strong track record as a funded collaborator on NIH and NSF grants.
+        Adding us to your proposal brings computational neuroimaging expertise, validated
+        open-source infrastructure, and Indiana University's institutional credibility
+        directly into your research team.
+      </p>
+
+      <div class="grant-track-record">
+        <div class="grant-stat">
+          <span class="grant-stat-num">20+</span>
+          <span class="grant-stat-label">Years of NIH &amp; NSF-funded research</span>
+        </div>
+        <div class="grant-stat">
+          <span class="grant-stat-num">3</span>
+          <span class="grant-stat-label">Active open-source ecosystems (DIPY, FURY, THETAN)</span>
+        </div>
+        <div class="grant-stat">
+          <span class="grant-stat-num">R1</span>
+          <span class="grant-stat-label">Indiana University — Carnegie R1 research institution</span>
+        </div>
+      </div>
+
+      <div class="grant-grid">
+
+        <div class="grant-card">
+          <h3 class="grant-card-title">What We Bring to Your Proposal</h3>
+          <ul class="grant-list">
+            <li>Established computational neuroimaging pipeline (DIPY) already cited in hundreds of peer-reviewed publications</li>
+            <li>Expertise in diffusion MRI, tractography, and brain connectivity analysis</li>
+            <li>Machine learning and scientific visualization capabilities (FURY, THETAN)</li>
+            <li>A multidisciplinary team spanning ISE, neuroscience, and clinical imaging</li>
+            <li>Proven ability to deliver reproducible, open-source software artifacts required by NIH data-sharing mandates</li>
+          </ul>
+        </div>
+
+        <div class="grant-card">
+          <h3 class="grant-card-title">What GRG Can Provide for Your Application</h3>
+          <ul class="grant-list">
+            <li><strong>Letter of Support</strong> — signed by Prof. Garyfallidis, outlining GRG's commitment and role</li>
+            <li><strong>NIH Biosketch</strong> — current biosketch for Prof. Garyfallidis and key personnel</li>
+            <li><strong>Facilities &amp; Resources statement</strong> — describing GRG compute infrastructure and IU HPC access</li>
+            <li><strong>Subaward / Subcontract setup</strong> — IU Sponsored Research Services handles all subcontract paperwork</li>
+            <li><strong>Scope of Work draft</strong> — tailored to your specific aims and budget period</li>
+          </ul>
+        </div>
+
+        <div class="grant-card">
+          <h3 class="grant-card-title">Common Collaboration Mechanisms</h3>
+          <ul class="grant-list">
+            <li><strong>NIH R01 / R21 subaward</strong> — GRG listed as subcontractor with dedicated budget</li>
+            <li><strong>NSF collaborative research</strong> — multi-PI or subaward structure through IU Sponsored Programs</li>
+            <li><strong>Consultant role</strong> — lighter engagement, no subcontract needed</li>
+            <li><strong>Co-investigator</strong> — for deeper, multi-year research partnerships where GRG leads a specific aim</li>
+            <li><strong>Data management plan contribution</strong> — GRG expertise in open-data and FAIR neuroimaging standards</li>
+          </ul>
+        </div>
+
+      </div>
+
+      <blockquote class="partnerships-billing-note" style="margin-top: 2rem;">
+        <strong>Ready to collaborate on a grant?</strong> Contact us early — ideally
+        4–6 weeks before your submission deadline — so we have time to prepare
+        the necessary documents and coordinate with
+        <strong>IU Sponsored Research Services</strong>.
+        Email <a href="mailto:workshop@dipy.org?subject=Grant Collaboration Inquiry" style="color: #800000;">workshop@dipy.org</a>
+        with your funding opportunity number and target submission date.
+      </blockquote>
+    </div>
+
+    <div class="divider"></div>
+
+    <!-- CTA -->
+    <div class="partnerships-section partnerships-cta" id="contact">
+      <h2 class="partnerships-section-title">Partner With Us Today</h2>
+      <p class="partnerships-cta-body">
+        Ready to streamline your team's imaging workflows or looking to clear
+        corporate procurement hurdles? Contact our fiscal and technical management
+        team to start the conversation.
+      </p>
+      <a
+        href="mailto:workshop@dipy.org?subject=Partnership Inquiry"
+        class="partnerships-cta-btn"
+      >
+        Email workshop@dipy.org
+      </a>
+      <p class="partnerships-cta-body" style="margin-top: 1.5rem;">
+        We will set up an introductory consultation and, upon request, provide an
+        official <strong>Indiana University invoice</strong> or
+        <strong>wire instruction packet</strong> through our IU Merchant accounts.
+      </p>
+      <blockquote class="partnerships-billing-note">
+        <strong>Corporate Billing Note:</strong> University billing is processed
+        smoothly via <strong>ACH&nbsp;/&nbsp;Wire Transfer</strong> and
+        <strong>Purchase Orders (POs)</strong> through Indiana University's
+        official merchant accounts — fully compliant with standard corporate
+        procurement requirements. Your finance team will have everything needed
+        for a clean approval cycle.
+      </blockquote>
+    </div>
+
+  </div>
+</section>
+
+{% endblock docs_main %}

--- a/_templates/pages/partnerships.html
+++ b/_templates/pages/partnerships.html
@@ -19,8 +19,7 @@
         <a href="mailto:workshop@dipy.org?subject=Partnership Inquiry" class="hero-btn hero-btn-primary">
           Email Us
         </a>
-        <!-- TODO: replace # with Google Calendar booking URL -->
-        <a href="#contact" class="hero-btn hero-btn-secondary">
+        <a href="https://calendar.app.google/H5gG9o2b2SfcrsQV7" target="_blank" rel="noopener noreferrer" class="hero-btn hero-btn-secondary">
           Book a Call
         </a>
       </div>
@@ -699,9 +698,10 @@
         >
           Email workshop@dipy.org
         </a>
-        <!-- TODO: replace # with Google Calendar booking URL -->
         <a
-          href="#"
+          href="https://calendar.app.google/H5gG9o2b2SfcrsQV7"
+          target="_blank"
+          rel="noopener noreferrer"
           class="partnerships-cta-btn partnerships-cta-btn-outline"
         >
           Book a Call
@@ -731,7 +731,7 @@
     Email Us
   </a>
   <!-- TODO: replace # with Google Calendar booking URL -->
-  <a href="#" class="sticky-cta-btn sticky-cta-call">
+  <a href="https://calendar.app.google/H5gG9o2b2SfcrsQV7" target="_blank" rel="noopener noreferrer" class="sticky-cta-btn sticky-cta-call">
     Book a Call
   </a>
 </div>

--- a/_templates/pages/partnerships.html
+++ b/_templates/pages/partnerships.html
@@ -15,6 +15,43 @@
         Accelerate your neuroimaging pipelines with direct access to the innovators
         behind DIPY, FURY, and THETAN.
       </p>
+      <div class="hero-cta-row">
+        <a href="mailto:workshop@dipy.org?subject=Partnership Inquiry" class="hero-btn hero-btn-primary">
+          Email Us
+        </a>
+        <!-- TODO: replace # with Google Calendar booking URL -->
+        <a href="#contact" class="hero-btn hero-btn-secondary">
+          Book a Call
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <!-- SOCIAL PROOF STATS BAR -->
+  <div class="stats-bar">
+    <div class="stat-item">
+      <span class="stat-num">10M+</span>
+      <span class="stat-label">DIPY downloads</span>
+    </div>
+    <div class="stat-divider"></div>
+    <div class="stat-item">
+      <span class="stat-num">700+</span>
+      <span class="stat-label">peer-reviewed citations</span>
+    </div>
+    <div class="stat-divider"></div>
+    <div class="stat-item">
+      <span class="stat-num">50+</span>
+      <span class="stat-label">contributing institutions worldwide</span>
+    </div>
+    <div class="stat-divider"></div>
+    <div class="stat-item">
+      <span class="stat-num">10+</span>
+      <span class="stat-label">years of annual workshops</span>
+    </div>
+    <div class="stat-divider"></div>
+    <div class="stat-item">
+      <span class="stat-num">R1</span>
+      <span class="stat-label">Indiana University</span>
     </div>
   </div>
 
@@ -31,12 +68,82 @@
       <div class="divider"></div>
     </div>
 
+    <!-- DIPY ECOSYSTEM -->
+    <div class="partnerships-section" id="ecosystem">
+      <h2 class="partnerships-section-title">The Global Ecosystem Behind GRG</h2>
+      <p class="partnerships-section-subtitle">
+        GRG is the headquarters and scientific lead of DIPY — but DIPY is an international
+        project. Partnering with GRG means partnering with the core of a worldwide
+        open-source community.
+      </p>
+
+      <div class="ecosystem-grid">
+
+        <div class="ecosystem-card ecosystem-card-featured">
+          <div class="ecosystem-card-header">
+            <img src="_static/images/logos/dipy-logo.png" alt="DIPY" class="ecosystem-logo" />
+            <span class="ecosystem-hq-badge">GRG Headquarters</span>
+          </div>
+          <h3 class="ecosystem-card-title">DIPY — Diffusion Imaging in Python</h3>
+          <p class="ecosystem-card-body">
+            The world's largest open-source library for diffusion MRI analysis. Originally
+            founded by Prof. Garyfallidis at the University of Cambridge, DIPY is today
+            maintained by an international team spanning five continents. GRG remains the
+            scientific lead and primary development hub — giving our partners direct
+            access to the people who design the algorithms, not just the documentation.
+          </p>
+          <div class="ecosystem-tags">
+            <span class="eco-tag">Tractography</span>
+            <span class="eco-tag">Signal Processing</span>
+            <span class="eco-tag">Registration</span>
+            <span class="eco-tag">Machine Learning</span>
+            <span class="eco-tag">Visualization</span>
+          </div>
+        </div>
+
+        <div class="ecosystem-right">
+
+          <div class="ecosystem-card">
+            <h3 class="ecosystem-card-title">Annual DIPY Workshop</h3>
+            <p class="ecosystem-card-body">
+              Every year GRG organizes the DIPY Workshop — a hands-on, internationally
+              attended training event that brings together neuroimaging researchers,
+              engineers, and clinicians to learn the latest methods in diffusion MRI
+              analysis directly from the core developers.
+            </p>
+            <a
+              href="https://workshop.dipy.org/2026"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="ecosystem-link"
+            >
+              DIPY Workshop 2026 &rarr;
+            </a>
+          </div>
+
+          <div class="ecosystem-card">
+            <h3 class="ecosystem-card-title">FURY &amp; THETAN</h3>
+            <p class="ecosystem-card-body">
+              Beyond DIPY, GRG leads <strong>FURY</strong> — a high-performance 3D
+              scientific visualization framework — and <strong>THETAN</strong>, a
+              next-generation machine learning framework targeting state-of-the-art
+              performance across neuroimaging and signal processing domains
+              (release planned Fall 2026).
+            </p>
+          </div>
+
+        </div>
+      </div>
+    </div>
+
+    <div class="divider"></div>
+
     <!-- WHY PARTNER -->
     <div class="partnerships-section" id="why-partner">
       <h2 class="partnerships-section-title">Why Partner with GRG?</h2>
       <p class="partnerships-section-subtitle">
         Bridging cutting-edge computational neuroengineering and real-world industrial
-        applications, GRG partnerships give your team an unfair advantage.
+        applications, GRG partnerships give your team a decisive advantage.
       </p>
       <div class="partnerships-pillars">
 
@@ -88,9 +195,9 @@
     <div class="partnerships-section" id="tiers">
       <h2 class="partnerships-section-title">Premium Partnership Tiers</h2>
       <p class="partnerships-section-subtitle">
-        Choose the engagement level that fits your team's scale, timeline, and
-        technical requirements. All tiers include access to our open-source
-        ecosystems; premium layers add direct human expertise.
+        All tiers include access to our open-source ecosystems — premium layers add
+        direct human expertise. Not sure which fits?
+        <a href="mailto:workshop@dipy.org?subject=Tier Question" style="color:#800000;">Ask us</a>.
       </p>
 
       <div class="tiers-grid">
@@ -104,6 +211,7 @@
               <span class="tier-amount">$2,500</span>
               <span class="tier-period">/ year</span>
             </div>
+            <p class="tier-value-anchor">Less than one conference registration + hotel</p>
             <p class="tier-tagline">
               For research groups leveraging GRG software in grant-funded studies.
             </p>
@@ -149,6 +257,7 @@
               <span class="tier-amount">$7,500</span>
               <span class="tier-period">/ year</span>
             </div>
+            <p class="tier-value-anchor">Less than two days of a senior consultant's time</p>
             <p class="tier-tagline">
               For biotech, medtech, and pharmaceutical R&amp;D teams integrating
               GRG pipelines into product workflows.
@@ -194,6 +303,7 @@
               <span class="tier-amount">$20,000</span>
               <span class="tier-period">/ year</span>
             </div>
+            <p class="tier-value-anchor">Fraction of one full-time neuroengineering hire</p>
             <p class="tier-tagline">
               For clinical-stage organizations requiring full validation support,
               regulatory-grade documentation, and named engineering resources.
@@ -231,58 +341,105 @@
         </div>
 
       </div>
+    </div>
 
-      <!-- Comparison summary table -->
-      <div class="tiers-table-wrap">
-        <h3 class="tiers-table-heading">At a Glance</h3>
-        <table class="tiers-table">
-          <thead>
-            <tr>
-              <th>Feature</th>
-              <th>Academic Lab<br /><em>$2,500 / yr</em></th>
-              <th class="col-featured">Corporate R&amp;D<br /><em>$7,500 / yr</em></th>
-              <th>Enterprise &amp; Clinical<br /><em>$20,000 / yr</em></th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>Workshop Access</td>
-              <td>Priority &amp; discounted</td>
-              <td class="col-featured">Up to 3 complimentary seats</td>
-              <td>Unlimited + private session</td>
-            </tr>
-            <tr>
-              <td>Support Channels</td>
-              <td>GitHub lane + email (48 hr)</td>
-              <td class="col-featured">Private Slack + email (24 hr)</td>
-              <td>Named engineer + phone</td>
-            </tr>
-            <tr>
-              <td>Private Consult Hours</td>
-              <td>4 hr / yr</td>
-              <td class="col-featured">16 hr / yr</td>
-              <td>48 hr / yr + quarterly reviews</td>
-            </tr>
-            <tr>
-              <td>Custom Algorithm Adaptation</td>
-              <td class="cell-no">&#8212;</td>
-              <td class="col-featured">Minor scope</td>
-              <td>Substantial co-development</td>
-            </tr>
-            <tr>
-              <td>Regulatory Compliance Docs</td>
-              <td class="cell-no">&#8212;</td>
-              <td class="col-featured cell-no">&#8212;</td>
-              <td>Full package + IU-signed letters</td>
-            </tr>
-            <tr>
-              <td>SLA &amp; Priority Patching</td>
-              <td class="cell-no">&#8212;</td>
-              <td class="col-featured">5 business days</td>
-              <td>48-hour critical response</td>
-            </tr>
-          </tbody>
-        </table>
+    <div class="divider"></div>
+
+    <!-- ONBOARDING TIMELINE -->
+    <div class="partnerships-section" id="onboarding">
+      <h2 class="partnerships-section-title">What Happens After You Sign</h2>
+      <p class="partnerships-section-subtitle">
+        No ambiguity. Here is exactly what the first 30 days look like.
+      </p>
+      <div class="timeline">
+        <div class="timeline-item">
+          <div class="timeline-marker">1</div>
+          <div class="timeline-content">
+            <h4 class="timeline-title">Day 1 — Welcome &amp; Access</h4>
+            <p class="timeline-body">
+              IU invoice or PO processed. You receive a welcome email with your
+              dedicated contact, Slack channel invite (Corporate+), and a link to
+              schedule your onboarding call.
+            </p>
+          </div>
+        </div>
+        <div class="timeline-connector"></div>
+        <div class="timeline-item">
+          <div class="timeline-marker">2</div>
+          <div class="timeline-content">
+            <h4 class="timeline-title">Week 1 — Onboarding Call</h4>
+            <p class="timeline-body">
+              30-minute video call with a GRG core developer. We audit your current
+              pipeline, define your primary use cases, and set priorities for the
+              year's consult hours.
+            </p>
+          </div>
+        </div>
+        <div class="timeline-connector"></div>
+        <div class="timeline-item">
+          <div class="timeline-marker">3</div>
+          <div class="timeline-content">
+            <h4 class="timeline-title">Week 2–4 — First Deliverable</h4>
+            <p class="timeline-body">
+              Based on your audit, we deliver an initial optimization report,
+              sequence recommendation, or algorithm adaptation scoped to your
+              tier — something concrete on your desk within the first month.
+            </p>
+          </div>
+        </div>
+        <div class="timeline-connector"></div>
+        <div class="timeline-item">
+          <div class="timeline-marker">4</div>
+          <div class="timeline-content">
+            <h4 class="timeline-title">Ongoing — Sustained Access</h4>
+            <p class="timeline-body">
+              Scheduled consult sessions, priority support queue, workshop
+              registration, and quarterly check-ins (Enterprise tier) throughout
+              the partnership year.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="divider"></div>
+
+    <!-- TESTIMONIALS -->
+    <div class="partnerships-section" id="testimonials">
+      <h2 class="partnerships-section-title">What Partners Say</h2>
+      <p class="partnerships-section-subtitle">
+        Trusted by researchers and engineering teams across academia and industry.
+      </p>
+      <div class="testimonials-grid">
+
+        <!-- TODO: replace with real testimonials -->
+        <div class="testimonial-card testimonial-placeholder">
+          <div class="testimonial-placeholder-inner">
+            <p class="testimonial-placeholder-text">
+              Testimonial from a partner researcher or lab director coming soon.
+            </p>
+            <span class="testimonial-placeholder-label">Academic Partner — Neuroimaging Lab</span>
+          </div>
+        </div>
+
+        <div class="testimonial-card testimonial-placeholder">
+          <div class="testimonial-placeholder-inner">
+            <p class="testimonial-placeholder-text">
+              Testimonial from a corporate R&amp;D partner coming soon.
+            </p>
+            <span class="testimonial-placeholder-label">Corporate R&amp;D Partner — Medtech</span>
+          </div>
+        </div>
+
+        <div class="testimonial-card testimonial-placeholder">
+          <div class="testimonial-placeholder-inner">
+            <p class="testimonial-placeholder-text">
+              Testimonial from a clinical sponsor or grant collaborator coming soon.
+            </p>
+            <span class="testimonial-placeholder-label">Enterprise Partner — Clinical Trial</span>
+          </div>
+        </div>
+
       </div>
     </div>
 
@@ -313,12 +470,18 @@
         </div>
       </div>
 
+      <!-- TODO: add real NIH/NSF award IDs below when available -->
+      <div class="grant-awards-note">
+        <span class="grant-awards-label">Selected funded awards:</span>
+        <span class="grant-award-placeholder">NIH Award #XXXXXXXX &nbsp;|&nbsp; NSF Award #XXXXXXX &nbsp;|&nbsp; <em>Additional awards to be listed</em></span>
+      </div>
+
       <div class="grant-grid">
 
         <div class="grant-card">
           <h3 class="grant-card-title">What We Bring to Your Proposal</h3>
           <ul class="grant-list">
-            <li>Established computational neuroimaging pipeline (DIPY) already cited in hundreds of peer-reviewed publications</li>
+            <li>Established computational neuroimaging pipeline (DIPY) already cited in 700+ peer-reviewed publications</li>
             <li>Expertise in diffusion MRI, tractography, and brain connectivity analysis</li>
             <li>Machine learning and scientific visualization capabilities (FURY, THETAN)</li>
             <li>A multidisciplinary team spanning ISE, neuroscience, and clinical imaging</li>
@@ -362,6 +525,113 @@
 
     <div class="divider"></div>
 
+    <!-- FAQ -->
+    <div class="partnerships-section" id="faq">
+      <h2 class="partnerships-section-title">Frequently Asked Questions</h2>
+
+      <div class="faq-list">
+
+        <div class="faq-item">
+          <button class="faq-question" aria-expanded="false">
+            Can we upgrade or change tiers mid-year?
+            <span class="faq-icon">&#43;</span>
+          </button>
+          <div class="faq-answer">
+            <p>
+              Yes. You can upgrade to a higher tier at any point during the year — we
+              pro-rate the difference and apply it immediately. Downgrades take effect
+              at the next annual renewal date.
+            </p>
+          </div>
+        </div>
+
+        <div class="faq-item">
+          <button class="faq-question" aria-expanded="false">
+            How does invoicing work? Can our procurement team use a Purchase Order?
+            <span class="faq-icon">&#43;</span>
+          </button>
+          <div class="faq-answer">
+            <p>
+              All billing runs through Indiana University's official merchant accounts.
+              We support <strong>ACH / Wire Transfer</strong> and
+              <strong>Purchase Orders (POs)</strong> — the same mechanisms Fortune 500
+              procurement teams use for university contracts. We provide a formal IU
+              invoice with all required vendor information. Contact us for a W-9 or
+              vendor setup forms.
+            </p>
+          </div>
+        </div>
+
+        <div class="faq-item">
+          <button class="faq-question" aria-expanded="false">
+            What if we need more consult hours than our tier includes?
+            <span class="faq-icon">&#43;</span>
+          </button>
+          <div class="faq-answer">
+            <p>
+              Additional consultation blocks are available for purchase at an hourly
+              rate reserved for active partners. We will notify you before you exhaust
+              your allotment so there are no surprises. Contact us to discuss your
+              typical usage and we can recommend the right tier from the start.
+            </p>
+          </div>
+        </div>
+
+        <div class="faq-item">
+          <button class="faq-question" aria-expanded="false">
+            Is DIPY still free? What exactly are we paying for?
+            <span class="faq-icon">&#43;</span>
+          </button>
+          <div class="faq-answer">
+            <p>
+              DIPY, FURY, and our other software will always remain free and open-source
+              under permissive licenses. A partnership tier purchases <em>direct human
+              access</em> — the time of the core developers who build the software —
+              along with SLA commitments, private communication channels, and tailored
+              deliverables that the open-source community model cannot provide at scale.
+            </p>
+          </div>
+        </div>
+
+        <div class="faq-item">
+          <button class="faq-question" aria-expanded="false">
+            We are an international team. Can we still partner with GRG?
+            <span class="faq-icon">&#43;</span>
+          </button>
+          <div class="faq-answer">
+            <p>
+              Absolutely. DIPY itself is an international project with contributors
+              and users across five continents. GRG operates as a globally collaborative
+              group and routinely works with labs and companies outside the United
+              States. IU handles international wire transfers and can provide the
+              necessary documentation for foreign procurement processes.
+            </p>
+          </div>
+        </div>
+
+        <div class="faq-item">
+          <button class="faq-question" aria-expanded="false">
+            What is the DIPY Workshop and is it included in my tier?
+            <span class="faq-icon">&#43;</span>
+          </button>
+          <div class="faq-answer">
+            <p>
+              The <a href="https://workshop.dipy.org/2026" target="_blank" rel="noopener noreferrer" style="color:#800000;">DIPY Workshop</a>
+              is an annual, internationally attended training event organized by GRG
+              where participants learn the latest diffusion MRI methods directly from
+              core developers. Academic tier partners receive discounted priority
+              registration; Corporate tier includes up to 3 complimentary seats;
+              Enterprise tier includes unlimited seats plus a private half-day session
+              with GRG leadership.
+            </p>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+    <div class="divider"></div>
+
     <!-- CTA -->
     <div class="partnerships-section partnerships-cta" id="contact">
       <h2 class="partnerships-section-title">Partner With Us Today</h2>
@@ -370,12 +640,21 @@
         corporate procurement hurdles? Contact our fiscal and technical management
         team to start the conversation.
       </p>
-      <a
-        href="mailto:workshop@dipy.org?subject=Partnership Inquiry"
-        class="partnerships-cta-btn"
-      >
-        Email workshop@dipy.org
-      </a>
+      <div class="cta-btn-row">
+        <a
+          href="mailto:workshop@dipy.org?subject=Partnership Inquiry"
+          class="partnerships-cta-btn"
+        >
+          Email workshop@dipy.org
+        </a>
+        <!-- TODO: replace # with Google Calendar booking URL -->
+        <a
+          href="#"
+          class="partnerships-cta-btn partnerships-cta-btn-outline"
+        >
+          Book a Call
+        </a>
+      </div>
       <p class="partnerships-cta-body" style="margin-top: 1.5rem;">
         We will set up an introductory consultation and, upon request, provide an
         official <strong>Indiana University invoice</strong> or
@@ -393,5 +672,43 @@
 
   </div>
 </section>
+
+<!-- STICKY FLOATING CTA -->
+<div class="sticky-cta" id="stickyCta">
+  <a href="mailto:workshop@dipy.org?subject=Partnership Inquiry" class="sticky-cta-btn sticky-cta-email">
+    Email Us
+  </a>
+  <!-- TODO: replace # with Google Calendar booking URL -->
+  <a href="#" class="sticky-cta-btn sticky-cta-call">
+    Book a Call
+  </a>
+</div>
+
+<script>
+(function () {
+  var hero = document.querySelector('.partnerships-hero');
+  var sticky = document.getElementById('stickyCta');
+  if (!hero || !sticky) return;
+  var observer = new IntersectionObserver(function (entries) {
+    sticky.classList.toggle('sticky-cta-visible', !entries[0].isIntersecting);
+  }, { threshold: 0 });
+  observer.observe(hero);
+
+  var faqButtons = document.querySelectorAll('.faq-question');
+  faqButtons.forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var expanded = this.getAttribute('aria-expanded') === 'true';
+      faqButtons.forEach(function (b) {
+        b.setAttribute('aria-expanded', 'false');
+        b.parentElement.classList.remove('faq-open');
+      });
+      if (!expanded) {
+        this.setAttribute('aria-expanded', 'true');
+        this.parentElement.classList.add('faq-open');
+      }
+    });
+  });
+}());
+</script>
 
 {% endblock docs_main %}

--- a/conf.py
+++ b/conf.py
@@ -165,6 +165,7 @@ html_additional_pages = {
     "publications": "pages/publications.html",
     "software": "pages/software.html",
     "career": "pages/career.html",
+    "partnerships": "pages/partnerships.html",
 }
 
 OUTPUT_DIR = "_templates/team"


### PR DESCRIPTION
## Summary

- New `/partnerships` page: hero, why-partner pillars, 3-tier pricing (Academic / Corporate R&D / Enterprise & Clinical), grant collaboration section, and CTA
- Navbar link added (desktop + mobile) with pill-style CTA treatment
- CSS scoped to `_static/css/grg/partnerships/partnerships.css`, imported in `main.css`
- Page registered in `conf.py` under `html_additional_pages`

## Grant collaboration section covers

- Track-record stats (20+ yrs NIH/NSF, 3 ecosystems, R1 institution)
- What GRG brings to a proposal
- Documents GRG can provide (letter of support, biosketch, facilities statement, subaward setup)
- Common mechanisms (R01/R21 subaward, NSF collab, consultant, co-PI)

## Test plan

- [x] `make clean && make html` builds without warnings
- [x] `/partnerships` page renders correctly in browser
- [x] All three tier cards display at desktop and mobile widths
- [x] Grant grid collapses to single column below 1100px
- [x] Navbar "Partner" link navigates to page
- [x] Email CTA links open correct mailto